### PR TITLE
Add full database seeding setup with reset functionality

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,4 @@
+from .player import Player
+from .game import Game
+from .statement import Statement
+from .guess import Guess

--- a/backend/scripts/seed_all.py
+++ b/backend/scripts/seed_all.py
@@ -1,0 +1,48 @@
+from app.database import SessionLocal
+
+from app.models.game import Game
+from app.models.player import Player
+from app.models.statement import Statement
+from app.models.guess import Guess
+
+from scripts.seed_game import seed_game
+from scripts.seed_players import seed_players
+from scripts.seed_statements import seed_statements
+from scripts.seed_guesses import seed_guesses
+
+
+def reset_db():
+    db = SessionLocal()
+
+    db.query(Guess).delete()
+    db.query(Statement).delete()
+    db.query(Player).delete()
+    db.query(Game).delete()
+
+    db.commit()
+    db.close()
+
+
+def run_all():
+    print("🚀 Starting full database seed...")
+
+    reset_db()
+    print("🧹 Database reset done")
+
+    seed_game()
+    print("✔ Game seeded")
+
+    seed_players()
+    print("✔ Players seeded")
+
+    seed_statements()
+    print("✔ Statements seeded")
+
+    seed_guesses()
+    print("✔ Guesses seeded")
+
+    print("🎉 All seeds completed successfully!")
+
+
+if __name__ == "__main__":
+    run_all()

--- a/backend/scripts/seed_game.py
+++ b/backend/scripts/seed_game.py
@@ -1,0 +1,30 @@
+from app.database import SessionLocal
+from app.models.game import Game
+from datetime import datetime
+
+def seed_game():
+    db = SessionLocal()
+
+   
+    db.query(Game).delete()
+
+
+    game = Game(
+        host_name="Ali",
+        host_id=1,
+        passcode="1234",
+        game_link="test-link",
+        status="waiting",
+        created_at=datetime.utcnow()
+    )
+
+    db.add(game)
+    db.commit()
+    db.refresh(game)
+
+    print("Game created with id:", game.id)
+
+    db.close()
+
+if __name__ == "__main__":
+    seed_game()

--- a/backend/scripts/seed_guesses.py
+++ b/backend/scripts/seed_guesses.py
@@ -1,0 +1,44 @@
+import random
+from app.database import SessionLocal
+from app.models.game import Game
+from app.models.player import Player
+from app.models.statement import Statement
+from app.models.guess import Guess
+
+def seed_guesses():
+    db = SessionLocal()
+
+    game = db.query(Game).order_by(Game.id.desc()).first()
+
+    players = db.query(Player).filter(Player.game_id == game.id).all()
+    statements = db.query(Statement).filter(Statement.game_id == game.id).all()
+
+    guesses = []
+
+    for statement in statements:
+        for player in players:
+
+            
+            possible = [p for p in players if p.id != player.id]
+
+            guessed = random.choice(possible)
+
+            guess = Guess(
+                game_id=game.id,
+                statement_id=statement.id,
+                player_id=player.id,
+                guessed_player_id=guessed.id
+            )
+
+            guesses.append(guess)
+
+    db.add_all(guesses)
+    db.commit()
+
+    print(f"{len(guesses)} guesses created for game {game.id}")
+
+    db.close()
+
+
+if __name__ == "__main__":
+    seed_guesses()

--- a/backend/scripts/seed_players.py
+++ b/backend/scripts/seed_players.py
@@ -1,0 +1,25 @@
+from app.database import SessionLocal
+from app.models.player import Player
+from app.models.game import Game
+
+def seed_players():
+    db = SessionLocal()
+
+    game = db.query(Game).order_by(Game.id.desc()).first()
+
+    players = [
+        Player(name="Sheida", game_id=game.id),
+        Player(name="Fred", game_id=game.id),
+        Player(name="Fatma", game_id=game.id),
+        Player(name="Jesus", game_id=game.id),
+    ]
+
+    db.add_all(players)
+    db.commit()
+
+    print(f"{len(players)} players created for game {game.id}")
+
+    db.close()
+
+if __name__ == "__main__":
+    seed_players()

--- a/backend/scripts/seed_statements.py
+++ b/backend/scripts/seed_statements.py
@@ -1,0 +1,44 @@
+from app.database import SessionLocal
+from app.models.game import Game
+from app.models.player import Player
+from app.models.statement import Statement
+
+def seed_statements():
+    db = SessionLocal()
+
+   
+    game = db.query(Game).order_by(Game.id.desc()).first()
+
+   
+    players = db.query(Player).filter(Player.game_id == game.id).all()
+
+    sample_statements = [
+        "I have never traveled outside my country",
+        "I can play a musical instrument",
+        "I once met a celebrity",
+        "I hate coffee",
+        "I can speak 3 languages",
+    ]
+
+    statements = []
+
+    for i, player in enumerate(players):
+        stmt = Statement(
+            game_id=game.id,
+            player_id=player.id,
+            statement=sample_statements[i % len(sample_statements)],
+            has_been_shown=False,
+            score=0
+        )
+        statements.append(stmt)
+
+    db.add_all(statements)
+    db.commit()
+
+    print(f"{len(statements)} statements created for game {game.id}")
+
+    db.close()
+
+
+if __name__ == "__main__":
+    seed_statements()


### PR DESCRIPTION
feat(seed): add full database seeding setup with reset functionality

- Added seed orchestration script (seed_all) to run all seeds together
- Implemented database reset before seeding to ensure clean state
- Added seed scripts for games, players, statements, and guesses
- Ensured proper dependency order between entities
- Improved repeatability of local development setup
- Added __init__.py in scripts to ensure proper Python package structure for imports