### PR TITLE
Prevent joining started or finished games & disable passcode autocomplete

### DIFF
--- a/frontend/js/joinGame.js
+++ b/frontend/js/joinGame.js
@@ -10,14 +10,38 @@ document.addEventListener("DOMContentLoaded", () => {
   const params = new URLSearchParams(window.location.search);
   const gameId = params.get("game_id");
   localStorage.setItem("game_id", gameId);
-  const urlPasscode = params.get("passcode");
-  
-  if (urlPasscode) {
-    passcode.value = urlPasscode;
+
+  let locked = false;
+  async function checkGameStatus() {
+    try {
+      const response = await fetch(`${API_BASE}/debug/game-status/${gameId}`);
+      if (!response.ok) throw new Error("Failed to fetch game status");
+
+      const data = await response.json();
+
+      if (data.status !== "waiting" && !locked) {
+        locked = true;
+        form.style.display = "none";
+        const p = document.createElement("p");
+        p.textContent = "Game already started.You can not join!";
+        p.className = "text-red-500 font-bold text-center text-lg";
+        form.parentNode.appendChild(p);
+      }
+      return data.status;
+    } catch (error) {
+      return null;
+    }
   }
+  checkGameStatus();
+  setInterval(checkGameStatus, 2000);
 
   form.addEventListener("submit", async (event) => {
     event.preventDefault();
+    const status = await checkGameStatus();
+
+    if (status !== "waiting") {
+      return;
+    }
 
     if (!gameId) {
       alert("Game not found");


### PR DESCRIPTION
1. Preventing automatic filling of the passcode field.
2. Checking the game's status before allowing a player to join:
   - If the game has already started or finished, the join form is hidden.
   - A red warning message is displayed informing the player they cannot join.
3. Continuously polling the game status every 2 seconds, ensuring the UI reflects the latest game state.
4. Keeping existing join functionality intact for games that are still in the 'waiting' state.
