### PR TITLE
feat:show real statement owner name on result page

### DIFF
--- a/backend/app/services/statement_service.py
+++ b/backend/app/services/statement_service.py
@@ -54,6 +54,7 @@ def get_results(db: Session, game_id: int):
                 "statement_id": s.id,
                 "statement": s.statement,
                 "score": s.score,
+                "owner_name":s.player.name
             }
         )
 

--- a/frontend/js/result.js
+++ b/frontend/js/result.js
@@ -28,7 +28,14 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const statementCard = document.createElement("div");
         statementCard.className = "statement-card";
-        statementCard.textContent = `${item.statement}`;
+
+        const statementText = document.createElement("p");
+        statementText.className = "statement-text";
+        statementText.textContent = item.statement;
+
+        const ownerName = document.createElement("span");
+        ownerName.className = "owner-name";
+        ownerName.textContent = `${item.owner_name}`;
 
         const scoreCard = document.createElement("div");
         scoreCard.className = "score-card";
@@ -37,6 +44,8 @@ document.addEventListener("DOMContentLoaded", () => {
         score.className = "font-semibold";
         score.textContent = `Score: ${item.score}`;
 
+        statementCard.appendChild(statementText);
+        statementCard.appendChild(ownerName);
         scoreCard.appendChild(score);
         resultItem.appendChild(statementCard);
         resultItem.appendChild(scoreCard);

--- a/frontend/style/style.css
+++ b/frontend/style/style.css
@@ -175,8 +175,18 @@ h1 {
 .statement-card {
   @apply bg-white p-6
   rounded-xl shadow-xl w-full md:w-96;
+  position: relative
 }
 .score-card {
   @apply bg-gray-500
   text-white px-4 py-2 rounded-lg;
+}
+.owner-name {
+  position: absolute;
+  bottom: 5px;
+  right: 14px;
+  font-size: 0.9rem;
+  font-style: italic;
+  font-weight: 700; 
+  color: black;
 }


### PR DESCRIPTION
This PR adds the real owner name of each statement to the Results page.
## Backend
- Included owner_name in the results API response.
## Frontend
- Rendered the statement owner name inside each result card.