### PR TITLE
Add pytest setup and database service tests

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,6 +13,7 @@ MarkupSafe==3.0.3
 psycopg2-binary==2.9.11
 pydantic==2.12.5
 pydantic_core==2.41.5
+pytest==9.0.3
 python-dotenv==1.2.2
 PyYAML==6.0.3
 SQLAlchemy==2.0.48

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from app.database import Base
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:" # create a temporary database in ram for testing
+
+engine = create_engine(SQLALCHEMY_DATABASE_URL)
+TestingSessionLocal = sessionmaker(bind=engine)
+
+
+@pytest.fixture
+def db():
+    Base.metadata.create_all(bind=engine) # take all models and create in temporary database
+    db = TestingSessionLocal()
+    yield db
+    db.close()

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,160 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+# test root endpoint
+def test_root_endpoint():
+    response = client.get("/")
+    assert response.status_code == 200
+
+
+# test create a game
+def test_create_game():
+    response = client.post("/games", json={"host_name": "Fred", "passcode": "1234"})
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "game_id" in data
+    assert data["status"] == "waiting"
+
+
+def test_create_game_without_host_name():
+    response = client.post("/games", json={"passcode": "1234"})
+    assert response.status_code == 422
+
+
+def test_start_game():
+    ## create a game
+    game = client.post("/games", json={"host_name": "Fatma", "passcode": "1234"}).json()
+
+    game_id = game["game_id"]
+
+    ## add 3 players
+    client.post(
+        f"/games/{game_id}/players",
+        json={"name": "Sheida", "statement": "Hello world", "passcode": "1234"},
+    )
+    client.post(
+        f"/games/{game_id}/players",
+        json={"name": "Fatma", "statement": "Hello world", "passcode": "1234"},
+    )
+    client.post(
+        f"/games/{game_id}/players",
+        json={"name": "Jesus", "statement": "Hello world", "passcode": "1234"},
+    )
+    ## game start
+    response = client.post(f"/games/{game_id}/start")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "in_progress"
+
+
+def test_start_noexist_game():
+    response = client.post("/games/324899/start")
+    assert response.status_code == 404
+
+
+def test_game_link_created():
+    game = client.post("/games", json={"host_name": "Fred", "passcode": "1234"}).json()
+
+    assert "game_link" in game
+    assert "game_id" in game["game_link"]
+    assert "host_id" in game["game_link"]
+
+
+# adding players
+def test_join_game():
+    game = client.post("games", json={"host_name": "Fred", "passcode": "1234"}).json()
+    game_id = game["game_id"]
+
+    response = client.post(
+        f"/games/{game_id}/players",
+        json={"name": "Sheida", "statement": "hello", "passcode": "1234"},
+    )
+    assert response.status_code == 200
+    assert response.json()["name"] == "Sheida"
+
+
+def test_join_game_without_statement():
+    game = client.post("/games", json={"host_name": "Fred", "passcode": "1234"}).json()
+
+    game_id = game["game_id"]
+
+    response = client.post(
+        f"/games/{game_id}/players",
+        json={
+            "name": "Sheida",
+            "passcode": "1234",
+            
+        },
+    )
+
+    assert response.status_code in [400, 422]
+
+
+
+def test_join_game_with_wrong_passcode():
+    game = client.post("games", json={"host_name": "Fred", "passcode": "1234"}).json()
+    game_id = game["game_id"]
+
+    response = client.post(
+        f"/games/{game_id}/players",
+        json={"name": "Sheida", "statement": "hello", "passcode": "999912399"},
+    )
+    assert response.status_code == 403
+    print("STATUS:", response.status_code)
+    print("BODY:", response.json())
+
+
+def test_join_game_without_passcode():
+    game = client.post("/games", json={"host_name": "Fred", "passcode": "1234"}).json()
+
+    game_id = game["game_id"]
+
+    response = client.post(
+        f"/games/{game_id}/players",
+        json={
+            "name": "Sheida",
+            "statement": "hello world!!",
+        },
+    )
+
+    assert response.status_code == 400
+
+
+def test_duplicate_player_name():
+    game = client.post("/games", json={"host_name": "Fred", "passcode": "1234"}).json()
+
+    game_id = game["game_id"]
+
+    client.post(
+        f"/games/{game_id}/players",
+        json={"name": "Sheida", "statement": "hello", "passcode": "1234"},
+    )
+
+    response = client.post(
+        f"/games/{game_id}/players",
+        json={"name": "Sheida", "statement": "hello again", "passcode": "1234"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_get_players():
+    game = client.post("/games", json={"host_name": "Fred", "passcode": "1234"}).json()
+
+    game_id = game["game_id"]
+
+    client.post(
+        f"/games/{game_id}/players",
+        json={"name": "Sheida", "statement": "hello world", "passcode": "1234"},
+    )
+
+    response = client.get(f"/games/{game_id}/players")
+
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -1,0 +1,111 @@
+from types import SimpleNamespace
+
+import pytest
+from app.services.game_service import create_game, start_game
+from app.services.guess_service import submit_guess
+from app.services.player_service import join_game
+from app.models.statement import Statement
+from app.models.player import Player
+
+def test_create_game_db(db):
+    game = create_game(db, host_name="Fred", passcode="121334")
+
+    assert game.id is not None
+    assert game.host_name == "Fred"
+    assert game.passcode == "121334"
+
+    assert game.game_link is not None
+    assert "game_id" in game.game_link
+    assert "host_id" in game.game_link
+
+
+def test_start_game_db(db):
+    game = create_game(db, host_name="Fatma", passcode="1234")
+
+    player = Player(game_id=game.id, name="Sheida")
+    db.add(player)
+    db.commit()
+    db.refresh(player)
+
+    statement = Statement(game_id=game.id, player_id=player.id, statement="Hello world")
+    db.add(statement)
+    db.commit()
+    db.refresh(statement)
+
+    started_game = start_game(db, game.id)
+
+    assert started_game.status == "in_progress"
+    assert started_game.current_statement_id == statement.id
+    assert started_game.round_started_at is not None
+
+
+def test_start_game_twice_db(db):
+    game = create_game(db, host_name="Fatma", passcode="1234")
+
+    player = Player(game_id=game.id, name="Sheida")
+    db.add(player)
+    db.commit()
+    db.refresh(player)
+
+    statement = Statement(
+        game_id=game.id,
+        player_id=player.id,
+        statement="Hello world",
+    )
+    db.add(statement)
+    db.commit()
+    db.refresh(statement)
+
+    first_start = start_game(db, game.id)
+
+    first_statement_id = first_start.current_statement_id
+    first_round_time = first_start.round_started_at
+
+    second_start = start_game(db, game.id)
+
+    assert second_start.current_statement_id == first_statement_id
+    assert second_start.round_started_at == first_round_time
+
+
+def test_submit_guess_correct_increases_score(db):
+    game = create_game(db, host_name="Fatma", passcode="1234")
+
+    p1 = join_game(db, game.id, "Jesus", "helloooo", "1234")
+
+    start_game(db, game.id)
+
+    statement = db.query(Statement).filter(Statement.game_id == game.id).first()
+
+    payload = SimpleNamespace(
+        statement_id=statement.id,
+        player_id=p1.id,
+        guessed_player_id=statement.player_id,
+    )
+
+    submit_guess(db, game.id, payload)
+
+    db.refresh(statement)
+
+    assert statement.score == 1
+
+
+def test_submit_guess_duplicate_not_allowed(db):
+    game = create_game(db, "Fatma", "1234")
+
+    p1 = join_game(db, game.id, "Jesus", "S1", "1234")
+    p2 = join_game(db, game.id, "Fatma", "S2", "1234")
+
+    start_game(db, game.id)
+
+    statement = db.query(Statement).filter(Statement.game_id == game.id).first()
+
+    payload = SimpleNamespace(
+        statement_id=statement.id,
+        player_id=p1.id,
+        guessed_player_id=p2.id,
+    )
+
+    submit_guess(db, game.id, payload)
+
+    with pytest.raises(Exception):
+        submit_guess(db, game.id, payload)


### PR DESCRIPTION
## Changes made:
- Added pytest testing framework to the project
- Updated requirements.txt with necessary dependencies
- Enabled running tests using the pytest command


 ## This PR includes tests for:

API endpoints
Service layer  functions

##  pytest.ini
- Added pythonpath = . to allow proper module imports from project root
- This ensures that modules like app.* can be imported correctly during tests
## conftest.py
- Created a fake in-memory database for testing
- Ensured test isolation (each test runs independently)
- Added automatic cleanup after each test