### PR TITLE
fix: improve duration input  for mobile

### DIFF
--- a/frontend/pages/create-game.html
+++ b/frontend/pages/create-game.html
@@ -53,7 +53,7 @@
                 Statement time limit
               </label>
 
-              <div class="relative">
+              <div class="flex flex-col sm:flex-row sm:items-center gap-2">
                 <input
                   type="text"
                   id="durationInput"
@@ -67,7 +67,7 @@
                 />
 
                 <span
-                  class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 text-sm"
+                  class="ml-2 text-gray-500 text-sm whitespace-nowrap"
                 >
                   seconds
                 </span>


### PR DESCRIPTION
### Problem
On mobile devices in portrait mode, the "seconds" label inside the duration input caused layout issues where the input value was partially hidden or overlapped, making it difficult for users to read what they typed.
### Result
- Duration input now displays correctly in portrait mode
- Improved readability and usability on small screens